### PR TITLE
Fix use of CSSTransitionGroup to work w/ modals.

### DIFF
--- a/components/modal.jsx
+++ b/components/modal.jsx
@@ -1,4 +1,5 @@
 var React = require('react/addons');
+var ReactCSSTransitionGroup = React.addons.CSSTransitionGroup;
 
 var ModalManagerMixin = require('../mixins/modal-manager');
 
@@ -21,24 +22,31 @@ var Modal = React.createClass({
     }
   },
   render: function() {
-    return (
+    var modal = (
       <div className="modal show"
-       role="dialog"
-       aria-labelledby="modal-label"
-       onClick={this.handleOutsideOfModalClick}>
-        <div className="modal-dialog">
-          <div className="modal-header">
-            <button type="button" className="close"
-             onClick={this.hideModal}>&times;</button>
-            <div className="modal-title" id="modal-label">
-              {this.props.modalTitle}
+         key={this.props.modalTitle}
+         role="dialog"
+         aria-labelledby="modal-label"
+         onClick={this.handleOutsideOfModalClick}>
+          <div className="modal-dialog">
+            <div className="modal-header">
+              <button type="button" className="close"
+               onClick={this.hideModal}>&times;</button>
+              <div className="modal-title" id="modal-label">
+                {this.props.modalTitle}
+              </div>
+            </div>
+            <div className="modal-body">
+              {this.props.children}
             </div>
           </div>
-          <div className="modal-body">
-            {this.props.children}
-          </div>
         </div>
-      </div>
+    );
+
+    return (
+      <ReactCSSTransitionGroup transitionName="modal">
+        {modal}
+      </ReactCSSTransitionGroup>
     );
   }
 });

--- a/components/modal.jsx
+++ b/components/modal.jsx
@@ -1,5 +1,4 @@
 var React = require('react/addons');
-var ReactCSSTransitionGroup = React.addons.CSSTransitionGroup;
 
 var ModalManagerMixin = require('../mixins/modal-manager');
 
@@ -22,7 +21,7 @@ var Modal = React.createClass({
     }
   },
   render: function() {
-    var modal = (
+    return (
       <div className="modal show"
          key={this.props.modalTitle}
          role="dialog"
@@ -41,12 +40,6 @@ var Modal = React.createClass({
             </div>
           </div>
         </div>
-    );
-
-    return (
-      <ReactCSSTransitionGroup transitionName="modal">
-        {modal}
-      </ReactCSSTransitionGroup>
     );
   }
 });

--- a/components/page.jsx
+++ b/components/page.jsx
@@ -1,4 +1,5 @@
-var React = require('react');
+var React = require('react/addons');
+var ReactCSSTransitionGroup = React.addons.CSSTransitionGroup;
 var Router = require('react-router');
 var RouteHandler = Router.RouteHandler;
 
@@ -75,13 +76,16 @@ var Page = React.createClass({
           </div>
           <Footer/>
         </div>
+
+        <ReactCSSTransitionGroup transitionName="modal">
         {this.state.modalClass
-         ? <div ref="modalHolder">
+         ? <div ref="modalHolder" key={1}>
              {React.createElement(this.state.modalClass,
                                   this.state.modalProps)}
              <div className="modal-backdrop"/>
            </div>
          : null}
+        </ReactCSSTransitionGroup>
       </div>
     );
   }

--- a/less/components/modal.less
+++ b/less/components/modal.less
@@ -98,15 +98,15 @@ body .modal {
 // modal fade in/out animation
 .modal-enter {
   opacity: 0.01;
-  transition: opacity 10s ease-in;
-  .modal-enter-active {
+  transition: opacity 0.25s ease-in;
+  &.modal-enter-active {
     opacity: 1;
   }
 }
 
 .modal-leave {
   opacity: 1;
-  transition: opacity 10s ease-in;
+  transition: opacity 0.25s ease-in;
   &.modal-leave-active {
     opacity: 0.01;
   }

--- a/less/components/modal.less
+++ b/less/components/modal.less
@@ -94,3 +94,20 @@ body .modal {
   /* Workaround for https://github.com/twbs/bootstrap/issues/14839. */
   -webkit-overflow-scrolling: auto;
 }
+
+// modal fade in/out animation
+.modal-enter {
+  opacity: 0.01;
+  transition: opacity 10s ease-in;
+  .modal-enter-active {
+    opacity: 1;
+  }
+}
+
+.modal-leave {
+  opacity: 1;
+  transition: opacity 10s ease-in;
+  &.modal-leave-active {
+    opacity: 0.01;
+  }
+}


### PR DESCRIPTION
(This is a potential fix for PR https://github.com/mozilla/teach.webmaker.org/pull/712. It's fine if it doesn't get merged in--I just had to put my solution somewhere and pasting the diff into a comment was a bit large-ish.)

The `CSSTransitionGroup` is funky and a bit hard to understand.

In order to have a CSS transition occur, the `CSSTransitionGroup` needs to exist both _before_ and _after_ the content you want to transition exists in React's virtual DOM, or else it won't actually have time to transition the content.

In your existing code, the lifetime of the `CSSTransitionGroup` was identical to the lifetime of the modal, so there wasn't actually any time for it to transition the modal in or out. But if we move that `CSSTransitionGroup` out to `Page.jsx` and have it _always_ exist, and only give it children when there is actually a modal to be shown, then it will have all the time it needs to transition its children in and out, since it's always in React's virtual DOM.

(Sorry, I think this PR actually contains stuff in `develop` that isn't yet in your feature branch, which makes this PR's diff log a bit hard to parse. The only useful commit in this PR is https://github.com/toolness/Mozilla-Learning/commit/43022b1ca5412d07cfee5bfb8a985a7ddd150e94 .)
