### PR TITLE
Generate index.html files for redirects.

### DIFF
--- a/lib/routes.jsx
+++ b/lib/routes.jsx
@@ -9,6 +9,7 @@ var ga = require('react-ga');
 var Page = require('../components/page.jsx');
 
 var urls = [];
+var redirects = {};
 
 var routes = (
   <Route handler={Page}>
@@ -26,7 +27,7 @@ var routes = (
      handler={require('../pages/clubs.jsx')}/>
     <Route name="web-lit-basics" path="/activities/web-lit-basics/"
      handler={require('../pages/web-lit-basics.jsx')}/>
-    <Redirect from="/clubs/curriculum/" to="web-lit-basics" />
+    <Redirect from="/clubs/curriculum/" to="/activities/web-lit-basics/" />
     <Route name="clubs-toolkit" path="/clubs/toolkit/"
      handler={require('../pages/clubs-toolkit.jsx')}/>
     <Route name="teach-like-mozilla" path="/teach-like-mozilla/"
@@ -40,14 +41,45 @@ var routes = (
 
 // TODO: come up with a better solution for nested route if we will ever have that.
 React.Children.forEach(routes.props.children, function(item) {
-  urls.push(item.props.path || '/');
+  var path = item.props.path;
+
+  if (!path && item.props.from) {
+    path = item.props.from;
+    redirects[path] = item.props.to;
+  }
+
+  urls.push(path || '/');
 });
 
 exports.URLS = urls;
 
 exports.routes = routes;
 
+exports.generateStaticRedirect = function(fromURL, toURL, cb) {
+  var router = Router.create({
+    routes: routes,
+    location: fromURL
+  });
+
+  process.nextTick(function() {
+    if (!router.match(toURL)) {
+      return cb(new Error("Redirect 'to' route does not exist: " + toURL));
+    }
+    html = React.renderToStaticMarkup(
+      <p>
+        The URL of this page has changed to <a href={toURL}>{toURL}</a>.
+      </p>
+    );
+    cb(null, html, {
+      title: "Redirect to " + toURL
+    });
+  });
+};
+
 exports.generateStatic = function(url, cb) {
+  if (url in redirects) {
+    return exports.generateStaticRedirect(url, redirects[url], cb);
+  }
   var router = Router.create({
     routes: routes,
     location: url


### PR DESCRIPTION
This creates an `index.html` page for each redirect.

On browsers without JS--and to robots--it looks like this:

![2015-05-18_8-11-44](https://cloud.githubusercontent.com/assets/124687/7680557/b85f8a58-fd35-11e4-9e80-c3a11fd7ff64.jpg)

However, browsers with JS will immediately load react-router, which will change the page's URL to the new location, and then present the user with the proper content.
